### PR TITLE
fix(types): add `splashscreen.useOriginalMsgbox`

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -202,6 +202,14 @@ export interface AppPlus {
      * 仅打包生效
      */
     sdkConfigs: Record<string, any>
+    /**
+     * Android使用原生隐私政策提示框
+     *
+     * @link https://uniapp.dcloud.net.cn/tutorial/app-privacy-android.html#
+     */
+    splashscreen?: {
+      useOriginalMsgbox?: boolean
+    }
   }
   /**
    * nvue 编译模式


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Thank you for contributing!
感谢你的贡献！

Before submitting the PR, please make sure you do the following:
在提交PR之前，请确保你做到以下几点：

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述
切换这个开关，会使`app-plus->distribute->splashscreen->useOriginalMsgbox`字段切换 `true` or `false`

![android-privacy-msbox-config](https://github.com/uni-helper/vite-plugin-uni-manifest/assets/30424139/253b7cd5-05b6-4be3-bee4-2e2dbbe7fab7)

### Linked Issues 关联的 Issues

### Additional context 额外上下文
