### PR TITLE
fix: resolve manifest config in HBuilderX

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,4 +1,5 @@
 import { existsSync, writeFileSync } from 'node:fs'
+import process from 'node:process'
 import { watchConfig } from 'c12'
 import { resolveOptions } from './options'
 import type { ResolvedOptions, UserOptions } from './types'
@@ -14,6 +15,7 @@ export class ManifestContext {
 
   async setup() {
     const { config, unwatch } = await watchConfig<UserManifestConfig>({
+      cwd: process.env.VITE_ROOT_DIR,
       name: 'manifest',
       defaultConfig: defaultManifestConfig,
       rcFile: false,


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Thank you for contributing! We highly recommend reading [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer) first to get an idea of our current state, and we appreciate your understanding!
感谢你的贡献！我们非常推荐先阅读 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer) 以了解我们目前的状态，感谢你的理解！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

在 HBuilderX 中，因为 vite 使用的版本是编辑器的插件：HBuilderX/plugins/uniapp-cli-vite
此时 process.cwd() 读取的路径目录也是 /path/HBuilderX/plugins/uniapp-cli-vite，
在这个目录下没有 manifest.config 配置文件，因此解析不到

#### 解决办法：
通过 option 传值进去指定项目 vite.config 所在的根目录
### Linked Issues 关联的 Issues
无
### Additional context 额外上下文

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->
在 HBuilderX 下运行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced the configuration setup for better project directory management.
	- Added the `cwd` property to improve functionality within the app.
	- Modified the `setup` method in the `ManifestContext` class.
	- Imported `process` from 'node:process'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->