### PR TITLE
fix: 生成的 manifest.json 文件最后增加空白换行符

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,21 @@ import Uni from '@dcloudio/vite-plugin-uni'
 import UniManifest from '@uni-helper/vite-plugin-uni-manifest'
 
 export default defineConfig({
-  plugins: [Uni(), UniManifest()],
+  plugins: [
+    UniManifest({
+      /**
+       * minify the `manifest.json`
+       * @default false
+       */
+      minify: true,
+      /**
+       * Controls whether a newline character is added at the end of the `manifest.json` file.
+       * @default false
+       */
+      newline: true
+    }),
+    Uni()
+  ],
 })
 ```
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -28,10 +28,12 @@ export class ManifestContext {
   }
 
   static WriteManifestJSON(config: any = {}, minify: boolean = false) {
-    writeFileSync(
-      manifestJsonPath,
-      JSON.stringify(config, null, minify ? 0 : 2),
-    )
+    // 生成配置内容字符串
+    let body = JSON.stringify(config, null, minify ? 0 : 2)
+    // 文件最后增加空白换行符
+    const r = body + "\n"
+    // 写入文件
+    writeFileSync(manifestJsonPath, r)
   }
 
   static CheckManifestJsonFile() {

--- a/src/context.ts
+++ b/src/context.ts
@@ -18,22 +18,24 @@ export class ManifestContext {
       defaultConfig: defaultManifestConfig,
       rcFile: false,
       packageJson: false,
-      onUpdate: (config) => {
-        ManifestContext.WriteManifestJSON(config.newConfig.config, this.options.minify)
+      onUpdate: (config: any) => {
+        ManifestContext.WriteManifestJSON(config.newConfig.config, this.options)
       },
     })
-    ManifestContext.WriteManifestJSON(config, this.options.minify)
+    ManifestContext.WriteManifestJSON(config, this.options)
 
     this.unwatch = unwatch
   }
 
-  static WriteManifestJSON(config: any = {}, minify: boolean = false) {
+  static WriteManifestJSON(config: any = {}, options: ResolvedOptions = { minify: false }) {
     // 生成配置内容字符串
-    let body = JSON.stringify(config, null, minify ? 0 : 2)
+    let body = JSON.stringify(config, null, options.minify ? 0 : 2)
     // 文件最后增加空白换行符
-    const finalContent = body + "\n"
+    if (options?.newline)
+      body = `${body}\n`
+
     // 写入文件
-    writeFileSync(manifestJsonPath, finalContent)
+    writeFileSync(manifestJsonPath, body)
   }
 
   static CheckManifestJsonFile() {

--- a/src/context.ts
+++ b/src/context.ts
@@ -31,9 +31,9 @@ export class ManifestContext {
     // 生成配置内容字符串
     let body = JSON.stringify(config, null, minify ? 0 : 2)
     // 文件最后增加空白换行符
-    const r = body + "\n"
+    const finalContent = body + "\n"
     // 写入文件
-    writeFileSync(manifestJsonPath, r)
+    writeFileSync(manifestJsonPath, finalContent)
   }
 
   static CheckManifestJsonFile() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,12 @@ export interface Options {
    * @default false
    */
   minify: boolean
+
+  /**
+   * `manifest.json` 最后增加换行符
+   * @default false
+   */
+  newline?: boolean
 }
 
 export interface UserOptions extends Partial<Options> {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface Options {
   minify: boolean
 
   /**
-   * `manifest.json` 最后增加换行符
+   * Controls whether a newline character is added at the end of the `manifest.json` file.
    * @default false
    */
   newline?: boolean


### PR DESCRIPTION
### Description 描述

生成的 manifest.json 文件最后增加空白换行符

** 问题 **
在使用 eslint 时会报错：
<img width="598" alt="image" src="https://github.com/uni-helper/vite-plugin-uni-manifest/assets/55943270/b2b29de9-77d5-4355-b94f-02bd67b99c53">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the file writing process for manifest JSON to improve formatting and content structure.
	- Updated the `WriteManifestJSON` method in the `ManifestContext` class for better configuration content generation.
	- Improved writing logic by appending a newline character at the end of the manifest JSON file.
	- Added an optional `newline` property to the `Options` interface in `src/types.ts`.
- **Documentation**
	- Updated README with new configuration options for `UniManifest` regarding minification and newline characters in `manifest.json`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->