### PR TITLE
fix: fix mp-weixin permission types

### DIFF
--- a/packages/core/src/config/types/mpWeixin.ts
+++ b/packages/core/src/config/types/mpWeixin.ts
@@ -197,15 +197,10 @@ export interface MpWeixin {
   navigateToMiniProgramAppIdList?: string[]
 
   /** 接口权限设置，详见 <https://developers.weixin.qq.com/miniprogram/dev/reference/configuration/app.html#permission> */
-  permission?: Record<
-    'scope.userLocation' |
-    'scope.userLocationBackground' |
-    'scope.userFuzzyLocation',
-    {
-      /** 小程序获取权限时展示的接口用途说明 */
-      desc: string
-    }
-  >
+  permission?: Partial<Record<'scope.userLocation' | 'scope.userLocationBackground' | 'scope.userFuzzyLocation', {
+    /** 小程序获取权限时展示的接口用途说明 */
+    desc: string
+  } >>;
 
   /** Worker 代码目录，详见 <https://developers.weixin.qq.com/miniprogram/dev/framework/workers.html> */
   workers?: string | {


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

`<Record<'scope.userLocation' | 'scope.userLocationBackground' | 'scope.userFuzzyLocation', {
    /** 小程序获取权限时展示的接口用途说明 */
    desc: string
  } >`
会导致一旦填写了permission配置项就必须填写上述代码中的所有权限(userLocation, userLocationBackground, userFuzzyLocation)
![image](https://github.com/user-attachments/assets/ff6a4a7b-2d4a-4d1a-96ca-a04f20435f30)

对其用Partial包括使其可选化
`Partial<Record<'scope.userLocation' | 'scope.userLocationBackground' | 'scope.userFuzzyLocation', {
        /** 小程序获取权限时展示的接口用途说明 */
        desc: string;
    }>>;`

### Linked Issues 关联的 Issues
fix https://github.com/uni-helper/vite-plugin-uni-manifest/issues/34

### Additional context 额外上下文
https://github.com/uni-helper/vite-plugin-uni-manifest/pull/35

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the flexibility of the `MpWeixin` interface, allowing developers to specify only the necessary permissions without requiring all permissions to be included. 

This change improves usability and customization for developers working with the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->