### PR TITLE
feat: add `swc` option for mp-weixin setting type

### DIFF
--- a/packages/core/src/config/types/mpWeixin.ts
+++ b/packages/core/src/config/types/mpWeixin.ts
@@ -42,6 +42,13 @@ export interface MpWeixin {
     /** 上传代码时是否自动压缩 WXML 文件 */
     minifyWXML?: boolean
 
+    /**
+     * 开启 swc 编译模式
+     *
+     * @default false
+     */
+    swc?: boolean
+
     /** 上传时是否代码保护 */
     uglifyFileName?: boolean
 


### PR DESCRIPTION
### Description 描述

在微信小程序项目配置的编译设置中新增 `swc` 选项，当前该配置项缺失导致使用该选项时 VS Code 编辑器代码警告提示。
详见微信官方文档：[小程序设置/项目配置文件](https://developers.weixin.qq.com/miniprogram/dev/devtools/projectconfig.html#setting)

![截图_20241126105310](https://github.com/user-attachments/assets/3798d856-c9a8-4366-8c65-ff9a2e6c9002)


### Linked Issues 关联的 Issues

无

### Additional context 额外上下文

无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `swc` property in the Weixin mini-program configuration, allowing developers to enable SWC compilation mode.
  
This enhancement provides greater flexibility in the development process for Weixin mini-programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->